### PR TITLE
Fix login DB env regression and unblock user-service deploy build

### DIFF
--- a/user-service/src/types/express/index.d.ts
+++ b/user-service/src/types/express/index.d.ts
@@ -1,0 +1,17 @@
+declare global {
+  namespace Express {
+    interface User {
+      [key: string]: any;
+    }
+
+    interface Request {
+      user?: User;
+      authInfo?: {
+        message?: string;
+        [key: string]: any;
+      };
+    }
+  }
+}
+
+export {};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix login DB resolution regression by making users DB env selection robust across `development`, `dev:start`, and `production`
- set `user-service` start script to `NODE_ENV=production` to avoid accidental development-mode config usage in hosted runtime
- update login reminder URL and environment docs/examples for hosted development app + Neon users DB host
- add Express request type augmentation for Passport (`request.user`, `request.authInfo`) to fix TypeScript CI/build failures in `user-service`
- add runtime DB target diagnostics for users DB connection (safe host/port/db only, no secrets):
  - logs `[DB_TARGET] users-service: host=... port=... db=... (stage=...)`
- harden login lookup by normalizing email and performing case-insensitive query to avoid false `Account not found` from casing mismatches
- add login miss diagnostic log:
  - `[LOGIN_LOOKUP_MISS] email=... stage=... usersDbConfigured=true|false`

## Why
`Account not found` can occur when the app points to the wrong DB or when email casing differs from stored values. This update both identifies the exact DB target at runtime and reduces false misses.

## Validation
- traced login miss path to `usersRepositories.getOne({ email })`
- added explicit users DB target log at DB initialization
- updated repository lookup to use `lower(email)` matching
- added miss logging in login service for operational verification
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d948fa9-ced0-4f6c-8d50-0850f3efa895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d948fa9-ced0-4f6c-8d50-0850f3efa895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

